### PR TITLE
 changed to use struct module instead of ustruct 

### DIFF
--- a/adafruit_lis3dh/lis3dh.py
+++ b/adafruit_lis3dh/lis3dh.py
@@ -1,9 +1,12 @@
-# Adafruit LIS3DH Accelerometer CircuitPython Driver
+struct# Adafruit LIS3DH Accelerometer CircuitPython Driver
 # Based on the Arduino LIS3DH driver from:
 #   https://github.com/adafruit/Adafruit_LIS3DH/
 # Author: Tony DiCola
 # License: MIT License (https://en.wikipedia.org/wiki/MIT_License)
-import ustruct
+try:
+    import struct
+else:
+    import ustruct as struct
 
 from micropython import const
 
@@ -96,9 +99,9 @@ class LIS3DH:
         a 3-tuple and are in m / s ^ 2.
         """
         data = self._read_register(REG_OUT_X_L | 0x80, 6)
-        x = ustruct.unpack('<h', data[0:2])[0]
-        y = ustruct.unpack('<h', data[2:4])[0]
-        z = ustruct.unpack('<h', data[4:6])[0]
+        x = struct.unpack('<h', data[0:2])[0]
+        y = struct.unpack('<h', data[2:4])[0]
+        z = struct.unpack('<h', data[4:6])[0]
         divider = 1
         accel_range = self.range
         if accel_range == RANGE_16_G:
@@ -118,7 +121,7 @@ class LIS3DH:
         if adc < 1 or adc > 3:
             raise ValueError('ADC must be a value 1 to 3!')
         data = self._read_register((REG_OUTADC1_L+((adc-1)*2)) | 0x80, 2)
-        return ustruct.unpack('<h', data[0:2])[0]
+        return struct.unpack('<h', data[0:2])[0]
 
     def read_adc_mV(self, adc):
         """Read the specified analog to digital converter value in millivolts.

--- a/adafruit_lis3dh/lis3dh.py
+++ b/adafruit_lis3dh/lis3dh.py
@@ -1,4 +1,4 @@
-struct# Adafruit LIS3DH Accelerometer CircuitPython Driver
+# Adafruit LIS3DH Accelerometer CircuitPython Driver
 # Based on the Arduino LIS3DH driver from:
 #   https://github.com/adafruit/Adafruit_LIS3DH/
 # Author: Tony DiCola

--- a/adafruit_lis3dh/lis3dh.py
+++ b/adafruit_lis3dh/lis3dh.py
@@ -5,7 +5,7 @@ struct# Adafruit LIS3DH Accelerometer CircuitPython Driver
 # License: MIT License (https://en.wikipedia.org/wiki/MIT_License)
 try:
     import struct
-else:
+except:
     import ustruct as struct
 
 from micropython import const

--- a/examples/spinner.py
+++ b/examples/spinner.py
@@ -8,7 +8,6 @@
 # License: MIT License (https://opensource.org/licenses/MIT)
 import math
 import time
-import ustruct
 
 import board
 import busio

--- a/examples/spinner_advanced.py
+++ b/examples/spinner_advanced.py
@@ -14,7 +14,6 @@
 # License: MIT License (https://opensource.org/licenses/MIT)
 import math
 import time
-import ustruct
 
 import board
 import busio


### PR DESCRIPTION
as a result of [adafruit/circuitpython] Refine `ustruct` into `struct` in shared-bindings and shared-module. (#205).  I this case i added try/except logic to make this code compatible with CPython 2.0 and 3.0