### PR TITLE
Stop mixing single and double tap detection.

### DIFF
--- a/examples/spinner.py
+++ b/examples/spinner.py
@@ -65,10 +65,10 @@ lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c, address=25)
 lis3dh.range = ACCEL_RANGE
 # Enable single click detection, but use a custom CLICK_CFG register value
 # to only detect clicks on the X axis (instead of all 3 X, Y, Z axes).
-lis3dh.set_click(1, TAP_THRESHOLD, click_cfg=0x01)
+lis3dh.set_tap(1, TAP_THRESHOLD, click_cfg=0x01)
 # Enable LIS3DH FIFO in stream mode.  This reaches in to the LIS3DH library to
 # call internal methods that change a few register values.  This must be done
-# AFTER calling set_click above because the set_click function also changes
+# AFTER calling set_tap above because the set_tap function also changes
 # REG_CTRL5.
 # pylint: disable=protected-access
 lis3dh._write_register_byte(adafruit_lis3dh.REG_CTRL5, 0b01001000)
@@ -85,7 +85,7 @@ last = time.monotonic()  # Keep track of the last time the loop ran.
 while True:
     # Read the raw click detection register value and check if there was
     # a click detected.
-    clicksrc = lis3dh.read_click_raw()
+    clicksrc = lis3dh._read_register_byte(adafruit_lis3dh.REG_CLICKSRC) # pylint: disable=protected-access
     if clicksrc & 0b01000000 > 0:
         # Click was detected!  Quickly read 32 values from the accelerometer
         # FIFO and look for the maximum magnitude values.

--- a/examples/spinner_advanced.py
+++ b/examples/spinner_advanced.py
@@ -183,10 +183,10 @@ lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c, address=25)
 lis3dh.range = ACCEL_RANGE
 # Enable single click detection, but use a custom CLICK_CFG register value
 # to only detect clicks on the X axis (instead of all 3 X, Y, Z axes).
-lis3dh.set_click(1, TAP_THRESHOLD, click_cfg=0x01)
+lis3dh.set_tap(1, TAP_THRESHOLD, click_cfg=0x01)
 # Enable LIS3DH FIFO in stream mode.  This reaches in to the LIS3DH library to
 # call internal methods that change a few register values.  This must be done
-# AFTER calling set_click above because the set_click function also changes
+# AFTER calling set_tap above because the set_tap function also changes
 # REG_CTRL5.  The FIFO stream mode will keep track of the 32 last X,Y,Z accel
 # readings in a FIFO buffer so they can be read later to see a history of
 # recent acceleration.  This is handy to look for the maximum/minimum impulse
@@ -219,7 +219,7 @@ while True:
     # Read the raw click detection register value and check if there was
     # a click detected.  Remember only the X axis causes clicks because of
     # the register configuration set previously.
-    clicksrc = lis3dh.read_click_raw()
+    clicksrc = lis3dh._read_register_byte(adafruit_lis3dh.REG_CLICKSRC) # pylint: disable=protected-access
     if clicksrc & 0b01000000 > 0:
         # Click was detected!  Quickly read 32 values from the accelerometer
         # and look for the maximum magnitude values.  Because the

--- a/examples/tap.py
+++ b/examples/tap.py
@@ -1,8 +1,7 @@
-# Click detection example.
+# Tap detection example.
 # Will loop forever printing when a single or double click is detected.
 # Open the serial port after running to see the output printed.
 # Author: Tony DiCola
-import time
 import board
 import adafruit_lis3dh
 
@@ -12,7 +11,12 @@ import adafruit_lis3dh
 # Hardware I2C setup:
 import busio
 i2c = busio.I2C(board.SCL, board.SDA)
-lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c)
+lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c, address=0x19)
+
+# Hardware I2C setup on CircuitPlayground Express:
+# import busio
+# i2c = busio.I2C(board.ACCELEROMETER_SCL, board.ACCELEROMETER_SDA)
+# lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c, address=0x19)
 
 # Software I2C setup:
 #import bitbangio
@@ -29,26 +33,23 @@ lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c)
 # Set range of accelerometer (can be RANGE_2_G, RANGE_4_G, RANGE_8_G or RANGE_16_G).
 lis3dh.range = adafruit_lis3dh.RANGE_2_G
 
-# Set click detection to double and single clicks.  The first parameter is a value:
-#  - 0 = Disable click detection.
-#  - 1 = Detect single clicks.
-#  - 2 = Detect single and double clicks.
+# Set tap detection to double taps.  The first parameter is a value:
+#  - 0 = Disable tap detection.
+#  - 1 = Detect single taps.
+#  - 2 = Detect double taps.
 # The second parameter is the threshold and a higher value means less sensitive
-# click detection.  Note the threshold should be set based on the range above:
+# tap detection.  Note the threshold should be set based on the range above:
 #  - 2G = 40-80 threshold
 #  - 4G = 20-40 threshold
 #  - 8G = 10-20 threshold
 #  - 16G = 5-10 threshold
-lis3dh.set_click(2, 80)
+lis3dh.set_tap(2, 80)
 
-# Loop forever printing if a single or double click is detected.
+# Loop forever printing if a double tap is detected. A single double tap may cause multiple
+# `tapped` reads to return true so we make sure the last once was False.
+last_tap = False
 while True:
-    # Read the click detection.  Two booleans are returned, single click and
-    # double click detected.  Each can be independently true/false.
-    single, double = lis3dh.read_click()
-    if single:
-        print('Single click!')
-    if double:
-        print('Double click!')
-    # Small delay to keep things responsive but give time for interrupt processing.
-    time.sleep(0.05)
+    tap = lis3dh.tapped
+    if tap and not last_tap:
+        print('Double tap!')
+    last_tap = tap


### PR DESCRIPTION
I haven't updated [the guide](https://learn.adafruit.com/circuitpython-hardware-lis3dh-accelerometer/software?view=all) that goes with this yet but will after the pull is accepted. We won't release it until [the CPX library](https://github.com/adafruit/Adafruit_CircuitPython_CircuitPlayground/) is forwards compatible.

The examples related to tap detection were tested on a CircuitPlayground Express.

---------------------------------------

This changes the API to have single boolean `tapped` property
(formerly read_click).

This change aligns the behavior with the expectation that a tap
thats part of a double tap does not register as a single tap. It
will now only detect single or double taps as set by `set_tap`.

Names with click were renamed to tap so they align with what is
actually happening rather than the data sheet names. A comment in
the code points this out.

The tap example now also deduplicates taps because tap detection
holds the status for a while.