### PR TITLE
Remove backwards compatibile imports

### DIFF
--- a/adafruit_lis3dh.py
+++ b/adafruit_lis3dh.py
@@ -33,14 +33,8 @@ Implementation Notes
 import time
 import math
 import digitalio
-try:
-    from collections import namedtuple
-except ImportError:
-    from ucollections import namedtuple
-try:
-    import struct
-except ImportError:
-    import ustruct as struct
+from collections import namedtuple
+import struct
 
 from micropython import const
 

--- a/adafruit_lis3dh.py
+++ b/adafruit_lis3dh.py
@@ -32,9 +32,9 @@ Implementation Notes
 
 import time
 import math
-import digitalio
 from collections import namedtuple
 import struct
+import digitalio
 
 from micropython import const
 


### PR DESCRIPTION
This saves 80 or so bytes when frozen into the CPX build