### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_lis3dh.py
+++ b/adafruit_lis3dh.py
@@ -42,7 +42,6 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_LIS3DH.git"
 
 # Register addresses:
-# pylint: disable=bad-whitespace
 _REG_OUTADC1_L = const(0x08)
 _REG_WHOAMI = const(0x0F)
 _REG_TEMPCFG = const(0x1F)
@@ -78,7 +77,6 @@ DATARATE_LOWPOWER_5KHZ = const(0b1001)
 
 # Other constants
 STANDARD_GRAVITY = 9.806
-# pylint: enable=bad-whitespace
 
 # the named tuple returned by the class
 AccelerationTuple = namedtuple("acceleration", ("x", "y", "z"))

--- a/examples/lis3dh_spinner.py
+++ b/examples/lis3dh_spinner.py
@@ -15,8 +15,8 @@ import busio
 
 from micropython import const
 
-import adafruit_lis3dh
 import neopixel
+import adafruit_lis3dh
 
 # Configuration:
 ACCEL_RANGE = adafruit_lis3dh.RANGE_16_G  # Accelerometer range.

--- a/examples/lis3dh_spinner_advanced.py
+++ b/examples/lis3dh_spinner_advanced.py
@@ -22,8 +22,8 @@ import digitalio
 
 from micropython import const
 
-import adafruit_lis3dh
 import neopixel
+import adafruit_lis3dh
 
 # Configuration:
 ACCEL_RANGE = adafruit_lis3dh.RANGE_16_G  # Accelerometer range.


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.