### PR TITLE
Update simpletest example

### DIFF
--- a/examples/lis3dh_simpletest.py
+++ b/examples/lis3dh_simpletest.py
@@ -8,23 +8,19 @@ import adafruit_lis3dh
 # otherwise check I2C pins.
 if hasattr(board, "ACCELEROMETER_SCL"):
     i2c = busio.I2C(board.ACCELEROMETER_SCL, board.ACCELEROMETER_SDA)
-    int1 = digitalio.DigitalInOut(board.ACCELEROMETER_INTERRUPT)
-    lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c, address=0x19, int1=int1)
+    lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c, address=0x19)
 else:
     i2c = busio.I2C(board.SCL, board.SDA)
-    int1 = digitalio.DigitalInOut(board.D6)  # Set to correct pin for interrupt!
-    lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c, int1=int1)
+    lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c)
 
 # Hardware SPI setup:
 # spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 # cs = digitalio.DigitalInOut(board.D5)  # Set to correct CS pin!
-# int1 = digitalio.DigitalInOut(board.D6)  # Set to correct pin for interrupt!
-# lis3dh = adafruit_lis3dh.LIS3DH_SPI(spi, cs, int1=int1)
+# lis3dh = adafruit_lis3dh.LIS3DH_SPI(spi, cs)
 
 # PyGamer or MatrixPortal I2C Setup:
 # i2c = busio.I2C(board.SCL, board.SDA)
-# int1 = digitalio.DigitalInOut(board.ACCELEROMETER_INTERRUPT)
-# lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c, address=0x19, int1=int1)
+# lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c, address=0x19)
 
 
 # Set range of accelerometer (can be RANGE_2_G, RANGE_4_G, RANGE_8_G or RANGE_16_G).

--- a/examples/lis3dh_simpletest.py
+++ b/examples/lis3dh_simpletest.py
@@ -1,6 +1,5 @@
 import time
 import board
-import digitalio
 import busio
 import adafruit_lis3dh
 


### PR DESCRIPTION
For #64 . Removes int pin setup and usage. Not really needed for a simpletest example and will make example more universally usable (some boards don't have internal pull ups).

```python
Adafruit CircuitPython 5.3.1 on 2020-07-13; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import lis3dh_simpletest
x = 0.024 G, y = 0.021 G, z = 0.983 G
x = 0.024 G, y = 0.024 G, z = 0.995 G
x = 0.023 G, y = 0.030 G, z = 0.998 G
x = 0.023 G, y = 0.026 G, z = 0.993 G
x = 0.024 G, y = 0.029 G, z = 0.994 G
x = 0.020 G, y = 0.025 G, z = 1.000 G
```