### PR TITLE
Updating library vs Datasheet

### DIFF
--- a/adafruit_lis3dh.py
+++ b/adafruit_lis3dh.py
@@ -65,7 +65,7 @@ RANGE_16_G = const(0b11)  # +/- 16g
 RANGE_8_G = const(0b10)  # +/- 8g
 RANGE_4_G = const(0b01)  # +/- 4g
 RANGE_2_G = const(0b00)  # +/- 2g (default value)
-DATARATE_1344_HZ = const(0b1001)  # 1.344 KHz
+DATARATE_1250_HZ = const(0b1001)  # 1.25 KHz
 DATARATE_400_HZ = const(0b0111)  # 400Hz
 DATARATE_200_HZ = const(0b0110)  # 200Hz
 DATARATE_100_HZ = const(0b0101)  # 100Hz
@@ -74,7 +74,7 @@ DATARATE_25_HZ = const(0b0011)  # 25Hz
 DATARATE_10_HZ = const(0b0010)  # 10 Hz
 DATARATE_1_HZ = const(0b0001)  # 1 Hz
 DATARATE_POWERDOWN = const(0)
-DATARATE_LOWPOWER_1K6HZ = const(0b1000)
+DATARATE_LOWPOWER_1K5HZ = const(0b1000)
 DATARATE_LOWPOWER_5KHZ = const(0b1001)
 
 # Other constants
@@ -125,6 +125,7 @@ class LIS3DH:
 
         Could have the following values:
 
+        * DATARATE_1250_HZ
         * DATARATE_400_HZ
         * DATARATE_200_HZ
         * DATARATE_100_HZ
@@ -133,7 +134,7 @@ class LIS3DH:
         * DATARATE_10_HZ
         * DATARATE_1_HZ
         * DATARATE_POWERDOWN
-        * DATARATE_LOWPOWER_1K6HZ
+        * DATARATE_LOWPOWER_1K5HZ
         * DATARATE_LOWPOWER_5KHZ.
 
         """


### PR DESCRIPTION
In doing some work to add type annotations I come across the difference between the library and the datasheet. Not sure if this is intentional or not, so if so please disregard this PR. I would work in the type annotatios afterwards. Thanks

**information source:**
https://cdn-shop.adafruit.com/datasheets/LIS3DHappnote.pdf
![image](https://user-images.githubusercontent.com/34255413/213270512-f0ea7040-f142-4a42-aa4c-042568d856d7.png)
