### PR TITLE
Add optional parameter for using internal pull-up for int1

### DIFF
--- a/adafruit_lis3dh.py
+++ b/adafruit_lis3dh.py
@@ -129,7 +129,10 @@ class LIS3DH:
         self._int2 = int2
         if self._int1:
             self._int1.direction = digitalio.Direction.INPUT
-            self._int1.pull = digitalio.Pull.UP
+            try:
+                self._int1.pull = digitalio.Pull.UP
+            except AttributeError:
+                pass
 
     @property
     def data_rate(


### PR DESCRIPTION
This is useful in cases where there is no support for internal pull-up resistor on the board (for example Binho Nova host adapter). On such devices, one have to use an external pull-up resistor.