### PR TITLE
Update shake() method

### DIFF
--- a/adafruit_lis3dh.py
+++ b/adafruit_lis3dh.py
@@ -215,7 +215,7 @@ class LIS3DH:
         return AccelerationTuple(x, y, z)
 
     def shake(
-        self, shake_threshold: int = 30, avg_count: int = 10, total_delay: float = 0.1
+        self, shake_threshold: int = 20, avg_count: int = 10, total_delay: float = 0.1
     ) -> bool:
         """Detect when the accelerometer is shaken. Optional parameters:
 
@@ -224,7 +224,7 @@ class LIS3DH:
                                     10 is the total acceleration if the board is not
                                     moving, therefore anything less than
                                     10 will erroneously report a constant shake detected.
-                                    Defaults to :const:`30`
+                                    Defaults to :const:`20`
 
         :param int avg_count: The number of readings taken and used for the average
                               acceleration. Default to :const:`10`
@@ -234,19 +234,15 @@ class LIS3DH:
 
         """
 
-        shake_accel = (0, 0, 0)
+        xs = ys = zs = 0
+        delay = total_delay / avg_count
         for _ in range(avg_count):
-            # shake_accel creates a list of tuples from acceleration data.
-            # zip takes multiple tuples and zips them together, as in:
-            # In : zip([-0.2, 0.0, 9.5], [37.9, 13.5, -72.8])
-            # Out: [(-0.2, 37.9), (0.0, 13.5), (9.5, -72.8)]
-            # map applies sum to each member of this tuple, resulting in a
-            # 3-member list. tuple converts this list into a tuple which is
-            # used as shake_accel.
-            shake_accel = tuple(map(sum, zip(shake_accel, self.acceleration)))
-            time.sleep(total_delay / avg_count)
-        avg = tuple(value / avg_count for value in shake_accel)
-        total_accel = math.sqrt(sum(map(lambda x: x * x, avg)))
+            x, y, z = self.acceleration
+            xs += x * x
+            ys += y * y
+            zs += z * z
+            time.sleep(delay)
+        total_accel = math.sqrt((xs + ys + zs) / avg_count)
         return total_accel > shake_threshold
 
     def read_adc_raw(self, adc: Literal[1, 2, 3]) -> int:

--- a/examples/lis3dh_shake.py
+++ b/examples/lis3dh_shake.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Carter Nelson for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+import time
+
+import board
+import busio
+
+import adafruit_lis3dh
+
+# Hardware I2C setup. Use the CircuitPlayground built-in accelerometer if available;
+# otherwise check I2C pins.
+if hasattr(board, "ACCELEROMETER_SCL"):
+    i2c = busio.I2C(board.ACCELEROMETER_SCL, board.ACCELEROMETER_SDA)
+    lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c, address=0x19)
+else:
+    i2c = board.I2C()  # uses board.SCL and board.SDA
+    # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
+    lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c)
+
+# Hardware SPI setup:
+# spi = board.SPI()
+# cs = digitalio.DigitalInOut(board.D5)  # Set to correct CS pin!
+# lis3dh = adafruit_lis3dh.LIS3DH_SPI(spi, cs)
+
+# PyGamer or MatrixPortal I2C Setup:
+# i2c = board.I2C()  # uses board.SCL and board.SDA
+# lis3dh = adafruit_lis3dh.LIS3DH_I2C(i2c, address=0x19)
+
+# Set range of accelerometer (can be RANGE_2_G, RANGE_4_G, RANGE_8_G or RANGE_16_G).
+# Increase as needed depending on the expected magintude of shaking.
+lis3dh.range = adafruit_lis3dh.RANGE_4_G
+
+# OPTIONAL: Set threshold for shake, default is 20
+# SHAKE_THRESH = 20
+
+# Loop forever checking for shake
+while True:
+    # Check for shake
+    if lis3dh.shake():
+        print("SHAKE!!!")
+    # Small delay to keep things responsive but give time for interrupt processing.
+    time.sleep(0.1)


### PR DESCRIPTION
Possible fix for #78.

This fixes the math logic in `shake()` and replaces the uberpythonic tuple/map/sum/zip approach with more simple code.

A new example `lis3dh_shake.py` is also added.

The default threshold has been reduced to `20` since `30` required fairly aggressive shaking. 

Is the simple code less performant? Simple performance check:
```py
import time
import board
import busio
import adafruit_lis3dh

i2c = busio.I2C(board.ACCELEROMETER_SCL, board.ACCELEROMETER_SDA)

lis = adafruit_lis3dh.LIS3DH_I2C(i2c, address=25)

while True:
    t1 = time.monotonic()
    lis.shake()
    t2 = time.monotonic()
    print("total time = ", t2-t1)
    time.sleep(1)
```

With existing `shake()` method:
```
Adafruit CircuitPython 10.0.3 on 2025-10-17; Adafruit Circuit Playground Bluefruit with nRF52840
>>> import lis_test
total time =  0.12207
total time =  0.123047
total time =  0.123047
total time =  0.123047
total time =  0.123047
```

With PR `shake()` method:
```
Adafruit CircuitPython 10.0.3 on 2025-10-17; Adafruit Circuit Playground Bluefruit with nRF52840
>>> import lis_test
total time =  0.120117
total time =  0.121094
total time =  0.12207
total time =  0.12207
total time =  0.12207
```

Note that `0.1` secs worth of this delay is part of the averaging delay in the `shake()` method. But TLDR = no significant difference in performance.